### PR TITLE
Use fixed width for show tiles

### DIFF
--- a/app/components/show-tile.tsx
+++ b/app/components/show-tile.tsx
@@ -8,8 +8,8 @@ export interface Props {
 
 export default function ShowTile({ show }: Props) {
   return (
-    <Link to={`/tv/${show.id}`} className="grow">
-      <div className="relative flex mb-3 flex-col rounded-lg border-2 border-mklight-100 hover:bg-mklight-100">
+    <Link to={`/tv/${show.id}`}>
+      <div className="relative mb-3 flex w-48 flex-col rounded-lg border-2 border-mklight-100 hover:bg-mklight-100">
         {show.imageUrl && (
           <img
             src={show.imageUrl}

--- a/app/components/show-tiles.tsx
+++ b/app/components/show-tiles.tsx
@@ -8,12 +8,10 @@ interface Props {
 
 export default function ShowTiles({ shows }: Props) {
   return (
-    <>
-      <div className="mt-3 flex flex-row flex-wrap items-stretch justify-between gap-3 grow">
-        {shows.map((show) => (
-          <ShowTile key={show.id} show={show} />
-        ))}
-      </div>
-    </>
+    <div className="mt-3 grid grid-cols-1 justify-items-center gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+      {shows.map((show) => (
+        <ShowTile key={show.id} show={show} />
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
This commit changes the show tiles to have a fixed width and uses a grid layout to display them. This prevents layout shift when the images load and ensures that the tiles are displayed in a consistent manner across different screen sizes.