### PR TITLE
Use same design for Upcoming and Recently Watched

### DIFF
--- a/app/components/episode-card.tsx
+++ b/app/components/episode-card.tsx
@@ -27,9 +27,7 @@ export default function EpisodeCard({ episode }: Props) {
         <p className="mt-2 text-sm text-gray-500">
           {new Date(episode.date).toLocaleDateString()}
         </p>
-        {episode.summary && (
-          <p className="mt-4 text-sm">{episode.summary}</p>
-        )}
+        {episode.summary && <p className="mt-4 text-sm">{episode.summary}</p>}
       </div>
     </li>
   );

--- a/app/routes/account.test.tsx
+++ b/app/routes/account.test.tsx
@@ -71,12 +71,14 @@ test("renders page", () => {
   expect(screen.getByText("Current Password")).toBeInTheDocument();
   expect(screen.getByText("New Password")).toBeInTheDocument();
   expect(screen.getByText("Confirm Password")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /Change password/i })).toBeInTheDocument();
   expect(
-    screen.getByText(/Deleting your account will also delete/),
+    screen.getByRole("button", { name: /Change password/i })
   ).toBeInTheDocument();
   expect(
-    screen.getByText(/Delete my account and all data/),
+    screen.getByText(/Deleting your account will also delete/)
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/Delete my account and all data/)
   ).toBeInTheDocument();
 });
 
@@ -180,7 +182,7 @@ test("renders success message", () => {
   render(<Account />);
 
   expect(
-    screen.getByText(/Your password has been changed/),
+    screen.getByText(/Your password has been changed/)
   ).toBeInTheDocument();
 });
 
@@ -233,7 +235,7 @@ test("action should return error if confirm password is invalid", async () => {
 
   // @ts-expect-error : we do not actually have a real response here..
   expect(response.data.errors.confirmPassword).toBe(
-    "Password confirmation is required",
+    "Password confirmation is required"
   );
 });
 
@@ -315,13 +317,13 @@ test("action should return error if change password fails", async () => {
 
   // @ts-expect-error : we do not actually have a real response here..
   expect(response.data.errors.generic).toBe(
-    "Something went wrong. Please try again.",
+    "Something went wrong. Please try again."
   );
 });
 
 test("action should return error if change password fails with expired reset", async () => {
   vi.mocked(changePassword).mockRejectedValue(
-    new Error("PASSWORD_RESET_EXPIRED"),
+    new Error("PASSWORD_RESET_EXPIRED")
   );
 
   const formData = new FormData();
@@ -340,7 +342,7 @@ test("action should return error if change password fails with expired reset", a
 
   // @ts-expect-error : we do not actually have a real response here..
   expect(response.data.errors.token).toBe(
-    "Password reset link expired. Please try again.",
+    "Password reset link expired. Please try again."
   );
 });
 
@@ -360,7 +362,7 @@ test("action should throw redirect if no logged in user", async () => {
       }),
       context: {},
       params: {},
-    }),
+    })
   ).rejects.toThrow();
 });
 
@@ -382,7 +384,7 @@ test("action should change password if everything ok", async () => {
   expect(changePassword).toBeCalledWith(
     "foo@example.com",
     "newnewPassword",
-    "",
+    ""
   );
 });
 
@@ -416,6 +418,6 @@ test("loader throws if there is no user", async () => {
       request: new Request("http://localhost:8080/account"),
       context: {},
       params: {},
-    }),
+    })
   ).rejects.toThrow();
 });

--- a/app/routes/tv.recent.test.tsx
+++ b/app/routes/tv.recent.test.tsx
@@ -5,15 +5,17 @@ import "@testing-library/jest-dom";
 import { getRecentlyWatchedEpisodes } from "../models/episode.server";
 import TVRecent, { loader } from "./tv.recent";
 
+const MOCK_DATE = new Date("2024-01-01");
+
 beforeEach(() => {
   vi.mock("react-router", () => {
     return {
       useLoaderData: vi.fn(),
     };
   });
-  vi.mock("../components/full-episodes-list", async () => {
+  vi.mock("../components/upcoming-episodes-list", async () => {
     return {
-      default: () => <p>FullEpisodesList</p>,
+      default: () => <p>UpcomingEpisodesList</p>,
     };
   });
   vi.mock("../models/episode.server", () => {
@@ -29,11 +31,11 @@ beforeEach(() => {
 
   vi.mocked(getRecentlyWatchedEpisodes).mockResolvedValue([
     {
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: MOCK_DATE,
+      updatedAt: MOCK_DATE,
       id: "1",
-      airDate: new Date(),
-      date: new Date(),
+      airDate: MOCK_DATE,
+      date: MOCK_DATE,
       imageUrl: "https://example.com/image.png",
       mazeId: "1",
       name: "Test Episode 1",
@@ -43,10 +45,10 @@ beforeEach(() => {
       showId: "1",
       summary: "Test Summary",
       show: {
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        createdAt: MOCK_DATE,
+        updatedAt: MOCK_DATE,
         id: "1",
-        premiered: new Date(),
+        premiered: MOCK_DATE,
         imageUrl: "https://example.com/image.png",
         mazeId: "maze1",
         name: "Test Show 1",
@@ -57,46 +59,53 @@ beforeEach(() => {
     },
   ]);
 
-  vi.mocked(useLoaderData<typeof loader>).mockReturnValue([
-    {
-      createdAt: new Date("2022-01-01"),
-      updatedAt: new Date("2022-01-01"),
-      id: "1",
-      airDate: new Date("2022-01-01"),
-      date: new Date("2022-01-01"),
-      imageUrl: "https://example.com/image.png",
-      mazeId: "1",
-      name: "Test Episode 1",
-      number: 1,
-      season: 1,
-      runtime: 30,
-      showId: "1",
-      summary: "Test Summary",
-      show: {
-        createdAt: new Date("2022-01-01"),
-        updatedAt: new Date("2022-01-01"),
+  const month = MOCK_DATE.toLocaleString("default", {
+    month: "long",
+    year: "numeric",
+  });
+
+  vi.mocked(useLoaderData<typeof loader>).mockReturnValue({
+    [month]: [
+      {
+        createdAt: MOCK_DATE,
+        updatedAt: MOCK_DATE,
         id: "1",
-        premiered: new Date("2022-01-01"),
+        airDate: MOCK_DATE,
+        date: MOCK_DATE,
         imageUrl: "https://example.com/image.png",
-        mazeId: "maze1",
-        name: "Test Show 1",
+        mazeId: "1",
+        name: "Test Episode 1",
+        number: 1,
+        season: 1,
+        runtime: 30,
+        showId: "1",
         summary: "Test Summary",
-        ended: null,
-        rating: 1,
+        show: {
+          createdAt: MOCK_DATE,
+          updatedAt: MOCK_DATE,
+          id: "1",
+          premiered: MOCK_DATE,
+          imageUrl: "https://example.com/image.png",
+          mazeId: "maze1",
+          name: "Test Show 1",
+          summary: "Test Summary",
+          ended: null,
+          rating: 1,
+        },
       },
-    },
-  ]);
+    ],
+  });
 });
 
 test("renders recently watched page", () => {
   render(<TVRecent />);
 
   expect(screen.getByText("Recently watched")).toBeInTheDocument();
-  expect(screen.getByText("FullEpisodesList")).toBeInTheDocument();
+  expect(screen.getByText("UpcomingEpisodesList")).toBeInTheDocument();
 });
 
 test("renders no recently watched episodes paragraph", () => {
-  vi.mocked(useLoaderData<typeof loader>).mockReturnValue([]);
+  vi.mocked(useLoaderData<typeof loader>).mockReturnValue({});
 
   render(<TVRecent />);
 
@@ -112,8 +121,13 @@ test("loader should return recently watched episodes", async () => {
     params: {},
   });
 
-  expect(result.length).toBe(1);
-  expect(result[0].name).toBe("Test Episode 1");
-  expect(result.length).toBe(1);
-  expect(result[0].show.name).toBe("Test Show 1");
+  const month = MOCK_DATE.toLocaleString("default", {
+    month: "long",
+    year: "numeric",
+  });
+
+  expect(Object.keys(result).length).toBe(1);
+  expect(result[month][0].name).toBe("Test Episode 1");
+  expect(result[month].length).toBe(1);
+  expect(result[month][0].show.name).toBe("Test Show 1");
 });

--- a/app/routes/tv.recent.tsx
+++ b/app/routes/tv.recent.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
 
-import FullEpisodesList from "../components/full-episodes-list";
+import UpcomingEpisodesList from "../components/upcoming-episodes-list";
 import { getRecentlyWatchedEpisodes } from "../models/episode.server";
 import { requireUserId } from "../session.server";
 
@@ -9,7 +9,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await requireUserId(request);
   const episodes = await getRecentlyWatchedEpisodes(userId);
 
-  return episodes;
+  const groupedEpisodes = episodes.reduce(
+    (acc, episode) => {
+      const month = new Date(episode.date).toLocaleString("default", {
+        month: "long",
+        year: "numeric",
+      });
+
+      if (!acc[month]) {
+        acc[month] = [];
+      }
+      acc[month].push(episode);
+      return acc;
+    },
+    {} as Record<string, typeof episodes>
+  );
+
+  return groupedEpisodes;
 }
 
 export default function TVUpcoming() {
@@ -18,10 +34,12 @@ export default function TVUpcoming() {
   return (
     <>
       <h1 className="font-title text-5xl">Recently watched</h1>
-      {episodes.length === 0 && (
+      {Object.keys(episodes).length === 0 && (
         <p className="mt-9">There are no recently watched episodes.</p>
       )}
-      {episodes.length > 0 && <FullEpisodesList episodes={episodes} />}
+      {Object.keys(episodes).length > 0 && (
+        <UpcomingEpisodesList episodes={episodes} />
+      )}
     </>
   );
 }

--- a/app/routes/tv.upcoming.tsx
+++ b/app/routes/tv.upcoming.tsx
@@ -22,7 +22,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       acc[month].push(episode);
       return acc;
     },
-    {} as Record<string, typeof episodes>,
+    {} as Record<string, typeof episodes>
   );
 
   return groupedEpisodes;


### PR DESCRIPTION
Updated the 'Recently watched' route to use the same design and data grouping as your 'Upcoming' route.

- The loader in `tv.recent.tsx` now groups episodes by month.
- The route now uses the `UpcomingEpisodesList` component to display the episodes.
- The tests for the route have been updated to reflect these changes.