### PR TITLE
Show stats on Recently Watched

### DIFF
--- a/app/components/upcoming-episodes-list.tsx
+++ b/app/components/upcoming-episodes-list.tsx
@@ -1,24 +1,70 @@
 import type { Episode, Show } from "@prisma/client";
 import EpisodeCard from "./episode-card";
 
-interface Props {
-  episodes: Record<
-    string,
-    (Episode & {
-      date: Date;
-      show: Show;
-    })[]
-  >;
+type EpisodeWithShow = Episode & {
+  date: Date;
+  show: Show;
+};
+
+interface WatchedEpisodes {
+  episodes: EpisodeWithShow[];
+  totalRuntime: number;
+  episodeCount: number;
+  showCount: number;
 }
 
-export default function UpcomingEpisodesList({ episodes }: Props) {
+interface Props {
+  episodes: Record<string, WatchedEpisodes | EpisodeWithShow[]>;
+  showStats?: boolean;
+}
+
+function formatRuntime(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  const hourText =
+    hours > 0 ? `${hours} ${hours === 1 ? "hour" : "hours"}` : "";
+  const minuteText =
+    remainingMinutes > 0
+      ? `${remainingMinutes} ${remainingMinutes === 1 ? "minute" : "minutes"}`
+      : "";
+
+  if (hourText && minuteText) {
+    return `${hourText} and ${minuteText}`;
+  }
+  return hourText || minuteText;
+}
+
+export default function UpcomingEpisodesList({ episodes, showStats }: Props) {
   return (
     <div className="my-3 flex flex-col py-5">
       {Object.keys(episodes).map((month) => (
         <div key={month} className="mt-8">
           <h2 className="font-title text-3xl">{month}</h2>
+          {showStats && (
+            <>
+              <div className="text-sm text-gray-500">
+                {formatRuntime(
+                  (episodes[month] as WatchedEpisodes).totalRuntime
+                )}
+              </div>
+              <div className="text-sm text-gray-500">
+                {(episodes[month] as WatchedEpisodes).episodeCount}{" "}
+                {(episodes[month] as WatchedEpisodes).episodeCount === 1
+                  ? "episode"
+                  : "episodes"}{" "}
+                from {(episodes[month] as WatchedEpisodes).showCount}{" "}
+                {(episodes[month] as WatchedEpisodes).showCount === 1
+                  ? "show"
+                  : "shows"}
+              </div>
+            </>
+          )}
           <div className="mt-4 flex flex-wrap gap-4">
-            {episodes[month].map((episode) => (
+            {(showStats
+              ? (episodes[month] as WatchedEpisodes).episodes
+              : (episodes[month] as EpisodeWithShow[])
+            ).map((episode) => (
               <EpisodeCard key={episode.id} episode={episode} />
             ))}
           </div>

--- a/app/routes/tv.recent.test.tsx
+++ b/app/routes/tv.recent.test.tsx
@@ -13,11 +13,7 @@ beforeEach(() => {
       useLoaderData: vi.fn(),
     };
   });
-  vi.mock("../components/upcoming-episodes-list", async () => {
-    return {
-      default: () => <p>UpcomingEpisodesList</p>,
-    };
-  });
+  vi.unmock("../components/upcoming-episodes-list");
   vi.mock("../models/episode.server", () => {
     return {
       getRecentlyWatchedEpisodes: vi.fn(),
@@ -41,7 +37,7 @@ beforeEach(() => {
       name: "Test Episode 1",
       number: 1,
       season: 1,
-      runtime: 30,
+      runtime: 90,
       showId: "1",
       summary: "Test Summary",
       show: {
@@ -65,43 +61,69 @@ beforeEach(() => {
   });
 
   vi.mocked(useLoaderData<typeof loader>).mockReturnValue({
-    [month]: [
-      {
-        createdAt: MOCK_DATE,
-        updatedAt: MOCK_DATE,
-        id: "1",
-        airDate: MOCK_DATE,
-        date: MOCK_DATE,
-        imageUrl: "https://example.com/image.png",
-        mazeId: "1",
-        name: "Test Episode 1",
-        number: 1,
-        season: 1,
-        runtime: 30,
-        showId: "1",
-        summary: "Test Summary",
-        show: {
+    [month]: {
+      episodes: [
+        {
           createdAt: MOCK_DATE,
           updatedAt: MOCK_DATE,
           id: "1",
-          premiered: MOCK_DATE,
+          airDate: MOCK_DATE,
+          date: MOCK_DATE,
           imageUrl: "https://example.com/image.png",
-          mazeId: "maze1",
-          name: "Test Show 1",
+          mazeId: "1",
+          name: "Test Episode 1",
+          number: 1,
+          season: 1,
+          runtime: 90,
+          showId: "1",
           summary: "Test Summary",
-          ended: null,
-          rating: 1,
+          show: {
+            createdAt: MOCK_DATE,
+            updatedAt: MOCK_DATE,
+            id: "1",
+            premiered: MOCK_DATE,
+            imageUrl: "https://example.com/image.png",
+            mazeId: "maze1",
+            name: "Test Show 1",
+            summary: "Test Summary",
+            ended: null,
+            rating: 1,
+          },
         },
-      },
-    ],
+      ],
+      totalRuntime: 90,
+      episodeCount: 1,
+      showCount: 1,
+    },
   });
 });
 
-test("renders recently watched page", () => {
+test("renders recently watched page with plural stats", () => {
   render(<TVRecent />);
 
   expect(screen.getByText("Recently watched")).toBeInTheDocument();
-  expect(screen.getByText("UpcomingEpisodesList")).toBeInTheDocument();
+  expect(screen.getByText("1 hour and 30 minutes")).toBeInTheDocument();
+  expect(screen.getByText("1 episode from 1 show")).toBeInTheDocument();
+});
+
+test("renders recently watched page with singular stats", () => {
+  const month = MOCK_DATE.toLocaleString("default", {
+    month: "long",
+    year: "numeric",
+  });
+  vi.mocked(useLoaderData<typeof loader>).mockReturnValue({
+    [month]: {
+      episodes: [],
+      totalRuntime: 61,
+      episodeCount: 2,
+      showCount: 2,
+    },
+  });
+  render(<TVRecent />);
+
+  expect(screen.getByText("Recently watched")).toBeInTheDocument();
+  expect(screen.getByText("1 hour and 1 minute")).toBeInTheDocument();
+  expect(screen.getByText("2 episodes from 2 shows")).toBeInTheDocument();
 });
 
 test("renders no recently watched episodes paragraph", () => {
@@ -127,7 +149,10 @@ test("loader should return recently watched episodes", async () => {
   });
 
   expect(Object.keys(result).length).toBe(1);
-  expect(result[month][0].name).toBe("Test Episode 1");
-  expect(result[month].length).toBe(1);
-  expect(result[month][0].show.name).toBe("Test Show 1");
+  expect(result[month].episodes[0].name).toBe("Test Episode 1");
+  expect(result[month].episodes.length).toBe(1);
+  expect(result[month].episodes[0].show.name).toBe("Test Show 1");
+  expect(result[month].totalRuntime).toBe(90);
+  expect(result[month].episodeCount).toBe(1);
+  expect(result[month].showCount).toBe(1);
 });

--- a/app/routes/tv.recent.tsx
+++ b/app/routes/tv.recent.tsx
@@ -17,13 +17,34 @@ export async function loader({ request }: LoaderFunctionArgs) {
       });
 
       if (!acc[month]) {
-        acc[month] = [];
+        acc[month] = {
+          episodes: [],
+          totalRuntime: 0,
+          episodeCount: 0,
+          showCount: 0,
+        };
       }
-      acc[month].push(episode);
+
+      acc[month].episodes.push(episode);
+      acc[month].totalRuntime += episode.runtime || 0;
+      acc[month].episodeCount++;
+
       return acc;
     },
-    {} as Record<string, typeof episodes>
+    {} as Record<
+      string,
+      {
+        episodes: typeof episodes;
+        totalRuntime: number;
+        episodeCount: number;
+        showCount: number;
+      }
+    >
   );
+
+  Object.values(groupedEpisodes).forEach((group) => {
+    group.showCount = new Set(group.episodes.map((e) => e.show.id)).size;
+  });
 
   return groupedEpisodes;
 }
@@ -38,7 +59,7 @@ export default function TVUpcoming() {
         <p className="mt-9">There are no recently watched episodes.</p>
       )}
       {Object.keys(episodes).length > 0 && (
-        <UpcomingEpisodesList episodes={episodes} />
+        <UpcomingEpisodesList episodes={episodes} showStats />
       )}
     </>
   );


### PR DESCRIPTION
On the 'Recently watched' route, I'll include the total of hours and minutes watched below the months' titles. I'll also include the number of episodes that were watched, in how many shows. This will only be shown on the 'Recently watched' route, and not on the 'Upcoming' route.