### PR TITLE
Redirect logged in users to /tv from index

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,12 +4,19 @@ import {
   EyeIcon,
   SparklesIcon,
 } from "@heroicons/react/24/outline";
-import { Link, useLoaderData } from "react-router";
+import type { LoaderFunctionArgs } from "react-router";
+import { Link, useLoaderData, redirect } from "react-router";
 
 import { getFlagsFromEnvironment } from "../models/config.server";
+import { getUserId } from "../session.server";
 import { useOptionalUser } from "../utils";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await getUserId(request);
+  if (userId) {
+    return redirect("/tv");
+  }
+
   const { SIGNUP_DISABLED } = getFlagsFromEnvironment();
   return { environment: { SIGNUP_DISABLED } };
 }


### PR DESCRIPTION
Redirect users to /tv from the index page if they are already logged in.

This is done by checking for a userId in the loader of the index route and redirecting to /tv if one is found.

Also adds a test case to verify the redirect.