### PR TITLE
Optimize show queries and update tests

### DIFF
--- a/app/models/show.server.test.ts
+++ b/app/models/show.server.test.ts
@@ -69,19 +69,20 @@ const SHOW2 = {
 };
 
 test("getAllRunningShowIds should return ids", async () => {
-  prisma.show.findMany.mockResolvedValue([SHOW, SHOW2]);
+  prisma.show.findMany.mockResolvedValue([SHOW, SHOW2] as any);
   const runningShowIds = await getAllRunningShowIds();
   expect(runningShowIds).toStrictEqual(["maze1", "maze2"]);
 });
 
 test("getShowsByUserId should return ids and unwatched count", async () => {
-  // @ts-expect-error we are not returning the full show object here
   prisma.showOnUser.findMany.mockResolvedValue([
     {
       archived: false,
       showId: "1",
       show: {
         ...SHOW,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 2,
         },
@@ -92,14 +93,15 @@ test("getShowsByUserId should return ids and unwatched count", async () => {
       showId: "2",
       show: {
         ...SHOW2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 1,
         },
       },
     },
-  ]);
-  // @ts-expect-error As we only select a subset of the fields, we do not need to mock everything
-  prisma.episodeOnUser.groupBy.mockResolvedValue([
+  ] as any);
+  (prisma.episodeOnUser.groupBy as any).mockResolvedValue([
     {
       showId: "1",
       _count: {
@@ -133,13 +135,14 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
   const SHOW_B = { ...SHOW, id: "b", name: "B show" };
   const SHOW_C = { ...SHOW, id: "c", name: "c show" };
 
-  // @ts-expect-error we are not returning the full show object here
   prisma.showOnUser.findMany.mockResolvedValue([
     {
       archived: false,
       showId: "c",
       show: {
         ...SHOW_C,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 2,
         },
@@ -150,6 +153,8 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
       showId: "a",
       show: {
         ...SHOW_A,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 2,
         },
@@ -160,16 +165,17 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
       showId: "b",
       show: {
         ...SHOW_B,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 2,
         },
       },
     },
-  ]);
+  ] as any);
 
   // All shows have 1 unwatched episode
-  // @ts-expect-error As we only select a subset of the fields, we do not need to mock everything
-  prisma.episodeOnUser.groupBy.mockResolvedValue([
+  (prisma.episodeOnUser.groupBy as any).mockResolvedValue([
     {
       showId: "a",
       _count: {
@@ -197,22 +203,22 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
 });
 
 test("getShowsByUserId should return 0 unwatched episodes for archived shows", async () => {
-  // @ts-expect-error we are not returning the full show object here
   prisma.showOnUser.findMany.mockResolvedValue([
     {
       archived: true,
       showId: "1",
       show: {
         ...SHOW,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 3,
         },
       },
     },
-  ]);
+  ] as any);
   // In theory we have 3 unwatched episodes here
-  // @ts-expect-error As we only select a subset of the fields, we do not need to mock everything
-  prisma.episodeOnUser.groupBy.mockResolvedValue([]);
+  (prisma.episodeOnUser.groupBy as any).mockResolvedValue([]);
   const shows = await getShowsByUserId("userId");
   expect(shows).toStrictEqual([
     {
@@ -230,13 +236,17 @@ test("getShowsByUserId should return empty array if not found", async () => {
 });
 
 test("getShowById should return users show with watched episodes", async () => {
-  prisma.showOnUser.findFirst.mockResolvedValue({
+  const showOnUser = {
+    id: "1",
+    showId: "2",
+    userId: "userId",
+    createdAt: new Date(),
+    updatedAt: new Date(),
     archived: false,
-    // @ts-expect-error TS does not know about the include..
     show: { ...SHOW2, episodes: [EPISODE4] },
-  });
-  // @ts-expect-error As we only select a subset of the fields, we do not need to mock everything
-  prisma.episodeOnUser.findMany.mockResolvedValue([{ episodeId: "4" }]);
+  };
+  prisma.showOnUser.findFirst.mockResolvedValue(showOnUser as any);
+  prisma.episodeOnUser.findMany.mockResolvedValue([{ episodeId: "4" }] as any);
   const shows = await getShowById("2", "userId");
   expect(shows).toStrictEqual({
     show: {
@@ -249,13 +259,14 @@ test("getShowById should return users show with watched episodes", async () => {
 });
 
 test("getSortedShowsByUserId should sort shows", async () => {
-  // @ts-expect-error we are not returning the full show object here
   prisma.showOnUser.findMany.mockResolvedValue([
     {
       archived: false,
       showId: "1",
       show: {
         ...SHOW,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 2,
         },
@@ -266,15 +277,16 @@ test("getSortedShowsByUserId should sort shows", async () => {
       showId: "2",
       show: {
         ...SHOW2,
+        createdAt: new Date(),
+        updatedAt: new Date(),
         _count: {
           episodes: 1,
         },
       },
     },
-  ]);
+  ] as any);
 
-  // @ts-expect-error As we only select a subset of the fields, we do not need to mock everything
-  prisma.episodeOnUser.groupBy.mockResolvedValue([
+  (prisma.episodeOnUser.groupBy as any).mockResolvedValue([
     {
       showId: "1",
       _count: {
@@ -345,7 +357,7 @@ test("getConnectedShowCount should return count", async () => {
       showId: "2",
       archived: false,
     },
-  ]);
+  ] as any);
   const count = await getConnectedShowCount();
   expect(count).toBe(2);
 });
@@ -430,7 +442,7 @@ test("searchShows should return fetched shows excluding already added shows", as
       },
     },
   ]);
-  prisma.show.findMany.mockResolvedValue([SHOW]);
+  prisma.show.findMany.mockResolvedValue([SHOW] as any);
 
   const searchResults = await searchShows("foo", "userId");
   expect(searchResults).toStrictEqual([show]);
@@ -493,7 +505,7 @@ test("addShow should add show and episodes", async () => {
     createdAt: new Date(),
     updatedAt: new Date(),
     id: recordId,
-  });
+  } as any);
 
   await addShow("userId", "maze1");
   expect(prisma.show.create).toBeCalledWith({
@@ -515,7 +527,7 @@ test("addShow should add show and episodes", async () => {
 });
 
 test("addShow should only connect show to user if already in database", async () => {
-  prisma.show.findFirst.mockResolvedValue(SHOW);
+  prisma.show.findFirst.mockResolvedValue(SHOW as any);
   prisma.showOnUser.findFirst.mockResolvedValue(null);
 
   await addShow("userId", SHOW.mazeId);
@@ -528,7 +540,7 @@ test("addShow should only connect show to user if already in database", async ()
 });
 
 test("addShow should not do anything if already connected", async () => {
-  prisma.show.findFirst.mockResolvedValue(SHOW);
+  prisma.show.findFirst.mockResolvedValue(SHOW as any);
   prisma.showOnUser.findFirst.mockResolvedValue({
     id: "1",
     createdAt: new Date(),
@@ -579,7 +591,7 @@ test("unarchiveShowOnUser should unarchive show", async () => {
 });
 
 test("getShowByUserIdAndName should return show by name for user", async () => {
-  prisma.show.findFirst.mockResolvedValue(SHOW);
+  prisma.show.findFirst.mockResolvedValue(SHOW as any);
 
   const result = await getShowByUserIdAndName({
     userId: "userId",

--- a/app/models/show.server.test.ts
+++ b/app/models/show.server.test.ts
@@ -1,3 +1,4 @@
+import type { Show, ShowOnUser, Episode } from "@prisma/client";
 import { prisma } from "../db.server";
 import {
   fetchSearchResults,
@@ -18,43 +19,9 @@ import {
   searchShows,
   unarchiveShowOnUser,
 } from "./show.server";
-import type {
-  Show,
-  ShowOnUser,
-  EpisodeOnUser,
-  Episode,
-} from "@prisma/client";
 
-vi.mock("../db.server", () => {
-  return {
-    prisma: {
-      show: {
-        findMany: vi.fn(),
-        findFirst: vi.fn(),
-        create: vi.fn(),
-        count: vi.fn(),
-        findUnique: vi.fn(),
-      },
-      showOnUser: {
-        findMany: vi.fn(),
-        deleteMany: vi.fn(),
-        create: vi.fn(),
-        findFirst: vi.fn(),
-        updateMany: vi.fn(),
-        groupBy: vi.fn(),
-      },
-      episodeOnUser: {
-        findMany: vi.fn(),
-        deleteMany: vi.fn(),
-        groupBy: vi.fn(),
-      },
-      episode: {
-        create: vi.fn(),
-        createMany: vi.fn(),
-      },
-    },
-  };
-});
+vi.mock("../db.server");
+
 vi.mock("./maze.server", async () => {
   return {
     fetchSearchResults: vi.fn(),
@@ -110,7 +77,9 @@ test("getAllRunningShowIds should return ids", async () => {
 });
 
 test("getShowsByUserId should return ids and unwatched count", async () => {
-  const showOnUserData: (ShowOnUser & { show: Show & { _count: { episodes: number } } })[] = [
+  const showOnUserData: (ShowOnUser & {
+    show: Show & { _count: { episodes: number } };
+  })[] = [
     {
       archived: false,
       showId: "1",
@@ -155,7 +124,8 @@ test("getShowsByUserId should return ids and unwatched count", async () => {
     },
   ];
   vi.mocked(prisma.showOnUser.findMany).mockResolvedValue(showOnUserData);
-  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData as any);
+  // @ts-expect-error .. we can ignore it here as we do not want to mock the full object
+  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData);
   const shows = await getShowsByUserId("userId");
   expect(shows).toStrictEqual([
     {
@@ -176,7 +146,9 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
   const SHOW_B = { ...SHOW, id: "b", name: "B show" };
   const SHOW_C = { ...SHOW, id: "c", name: "c show" };
 
-  const showOnUserData: (ShowOnUser & { show: Show & { _count: { episodes: number } } })[] = [
+  const showOnUserData: (ShowOnUser & {
+    show: Show & { _count: { episodes: number } };
+  })[] = [
     {
       archived: false,
       showId: "c",
@@ -243,7 +215,8 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
     },
   ];
   vi.mocked(prisma.showOnUser.findMany).mockResolvedValue(showOnUserData);
-  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData as any);
+  // @ts-expect-error .. we can ignore it here as we do not want to mock the full object
+  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData);
 
   const shows = await getSortedShowsByUserId("userId");
   const showNames = shows.map((s) => s.name);
@@ -252,7 +225,9 @@ test("getSortedShowsByUserId should sort shows case-insensitively", async () => 
 });
 
 test("getShowsByUserId should return 0 unwatched episodes for archived shows", async () => {
-  const showOnUserData: (ShowOnUser & { show: Show & { _count: { episodes: number } } })[] = [
+  const showOnUserData: (ShowOnUser & {
+    show: Show & { _count: { episodes: number } };
+  })[] = [
     {
       archived: true,
       showId: "1",
@@ -297,7 +272,10 @@ test("getShowById should return users show with watched episodes", async () => {
     show: { ...SHOW2, episodes: [EPISODE4] },
   };
   vi.mocked(prisma.showOnUser.findFirst).mockResolvedValue(showOnUser);
-  vi.mocked(prisma.episodeOnUser.findMany).mockResolvedValue([{ episodeId: "4" } as any]);
+  vi.mocked(prisma.episodeOnUser.findMany).mockResolvedValue([
+    // @ts-expect-error .. we can ignore it here as we do not want to mock the full object
+    { episodeId: "4" },
+  ]);
   const shows = await getShowById("2", "userId");
   expect(shows).toStrictEqual({
     show: {
@@ -310,7 +288,9 @@ test("getShowById should return users show with watched episodes", async () => {
 });
 
 test("getSortedShowsByUserId should sort shows", async () => {
-  const showOnUserData: (ShowOnUser & { show: Show & { _count: { episodes: number } } })[] = [
+  const showOnUserData: (ShowOnUser & {
+    show: Show & { _count: { episodes: number } };
+  })[] = [
     {
       archived: false,
       showId: "1",
@@ -355,7 +335,8 @@ test("getSortedShowsByUserId should sort shows", async () => {
     },
   ];
   vi.mocked(prisma.showOnUser.findMany).mockResolvedValue(showOnUserData);
-  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData as any);
+  // @ts-expect-error .. we can ignore it here as we do not want to mock the full object
+  vi.mocked(prisma.episodeOnUser.groupBy).mockResolvedValue(episodeOnUserData);
 
   const shows = await getSortedShowsByUserId("userId");
 

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -333,6 +333,11 @@ export async function addShow(userId: User["id"], showId: Show["mazeId"]) {
       where: { userId, showId: alreadyExistingShow.id },
     });
 
+    console.log("Already existing show", {
+      alreadyExistingShow,
+      alreadyAddedConnection,
+    });
+
     if (alreadyAddedConnection) {
       return {};
     }

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -49,55 +49,78 @@ export async function getShowByUserIdAndName({
 }
 
 export async function getShowsByUserId(userId: User["id"]) {
-  // We are querying showOnUser so that we can easier get the
-  // attributes off of this table, such as "archived". We then
-  // later on map it to get an easier data structure.
   const showsOnUser = await prisma.showOnUser.findMany({
     where: {
       userId,
     },
-    include: {
+    select: {
+      showId: true,
+      archived: true,
       show: {
-        include: {
-          episodes: true,
+        select: {
+          id: true,
+          mazeId: true,
+          name: true,
+          premiered: true,
+          ended: true,
+          rating: true,
+          imageUrl: true,
+          summary: true,
+          _count: {
+            select: {
+              episodes: {
+                where: {
+                  airDate: {
+                    lt: new Date(),
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },
   });
 
-  if (!showsOnUser) {
+  if (!showsOnUser.length) {
     return [];
   }
 
-  const shows = showsOnUser.map((showOnUser) => ({
-    ...showOnUser.show,
-    archived: showOnUser.archived,
-  }));
+  const showIds = showsOnUser.map((s) => s.showId);
 
-  if (!shows) {
-    return [];
-  }
-
-  const watchedEpisodes = await prisma.episodeOnUser.findMany({
+  const watchedEpisodesCount = await prisma.episodeOnUser.groupBy({
+    by: ["showId"],
+    _count: {
+      episodeId: true,
+    },
     where: {
       userId,
+      showId: {
+        in: showIds,
+      },
     },
   });
 
-  const showsToReturn = shows.map((show) => {
-    const watchedEpisodeForShow = watchedEpisodes.filter(
-      (episode) => episode.showId === show.id
-    );
-    const pastEpisodes = show.episodes.filter(
-      (episode) => episode.airDate < new Date()
-    );
-    const unwatchedEpisodesCount = show.archived
+  const watchedEpisodesCountMap = new Map<string, number>();
+  for (const group of watchedEpisodesCount) {
+    watchedEpisodesCountMap.set(group.showId, group._count.episodeId);
+  }
+
+  const showsToReturn = showsOnUser.map(({ show, archived, showId }) => {
+    const pastEpisodesCount = show._count.episodes;
+    const watchedCount = watchedEpisodesCountMap.get(showId) || 0;
+    const unwatchedEpisodesCount = archived
       ? 0
-      : pastEpisodes.length - watchedEpisodeForShow.length;
+      : pastEpisodesCount - watchedCount;
+
+    // Eslint doesn't like this, however we want to remove this property
+    // from the object we are returning
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { _count, ...showData } = show;
 
     return {
-      ...show,
-      episodes: undefined, // we do not need the episodes here anymore, so no need to transfer it
+      ...showData,
+      archived,
       unwatchedEpisodesCount,
     };
   });
@@ -172,6 +195,9 @@ export async function getShowById(showId: Show["id"], userId: User["id"]) {
       where: {
         userId,
         showId,
+      },
+      select: {
+        episodeId: true,
       },
     }),
   ]);
@@ -341,14 +367,12 @@ export async function addShow(userId: User["id"], showId: Show["mazeId"]) {
     },
   });
 
-  for (const episode of episodes) {
-    await prisma.episode.create({
-      data: {
-        ...episode,
-        showId: record.id,
-      },
-    });
-  }
+  await prisma.episode.createMany({
+    data: episodes.map((episode) => ({
+      ...episode,
+      showId: record.id,
+    })),
+  });
 
   return {};
 }

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -333,11 +333,6 @@ export async function addShow(userId: User["id"], showId: Show["mazeId"]) {
       where: { userId, showId: alreadyExistingShow.id },
     });
 
-    console.log("Already existing show", {
-      alreadyExistingShow,
-      alreadyAddedConnection,
-    });
-
     if (alreadyAddedConnection) {
       return {};
     }

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -66,6 +66,8 @@ export async function getShowsByUserId(userId: User["id"]) {
           rating: true,
           imageUrl: true,
           summary: true,
+          createdAt: true,
+          updatedAt: true,
           _count: {
             select: {
               episodes: {


### PR DESCRIPTION
- Refactored `getShowsByUserId` to be more performant by using `_count` and `groupBy` to reduce database queries.
- Refactored `addShow` to use `createMany` for batch episode creation.
- Optimized `getShowById` to only select necessary fields.
- Updated all relevant tests to reflect the changes and ensure they pass.