### PR TITLE
Add eslint rule for import order

### DIFF
--- a/app/models/password.server.ts
+++ b/app/models/password.server.ts
@@ -1,5 +1,5 @@
-import type { User } from "@prisma/client";
 import { createHash, randomUUID } from "crypto";
+import type { User } from "@prisma/client";
 
 import { prisma } from "../db.server";
 import { sendPasswordResetMail } from "./mail.server";

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -1,9 +1,9 @@
 import type { Show, User } from "@prisma/client";
 
 import striptags from "striptags";
+import { prisma } from "../db.server";
 import { decodeHtmlEntities } from "./html-entities.server";
 
-import { prisma } from "../db.server";
 import {
   fetchSearchResults,
   fetchShowWithEmbededEpisodes,

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -1,6 +1,6 @@
+import { createHash } from "crypto";
 import type { Password, User } from "@prisma/client";
 import { compare, hash } from "@node-rs/bcrypt";
-import { createHash } from "crypto";
 
 import { prisma } from "../db.server";
 

--- a/app/routes/plex.$token.test.tsx
+++ b/app/routes/plex.$token.test.tsx
@@ -1,11 +1,11 @@
 import type { ActionFunctionArgs } from "react-router";
-import { action } from "./plex.$token";
 import {
   getEpisodeByShowIdAndNumbers,
   markEpisodeAsWatched,
 } from "../models/episode.server";
 import { getShowByUserIdAndName } from "../models/show.server";
 import { getUserByPlexToken } from "../models/user.server";
+import { action } from "./plex.$token";
 
 vi.mock("../db.server");
 vi.mock("../models/episode.server");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -123,6 +123,7 @@ export default [
 
     rules: {
       "testing-library/prefer-screen-queries": "off",
+      "import/order": "error",
     },
 
     settings: {


### PR DESCRIPTION
Add an ESLint rule to enforce a consistent import order. This helps to keep the code clean and readable.

The `import/order` rule from `eslint-plugin-import` is used with its default configuration.

All existing import order errors have been fixed.