### PR TITLE
Implement feature flags for password change, account deletion and Plex

### DIFF
--- a/app/flags.server.ts
+++ b/app/flags.server.ts
@@ -33,6 +33,9 @@ export const FLAGS = {
   FETCH_FROM_SOURCE: "fetch-from-source",
   SEARCH: "search",
   ADD_SHOW: "add-show",
+  PASSWORD_CHANGE: "password-change",
+  DELETE_ACCOUNT: "delete-account",
+  PLEX: "plex",
 };
 
 export async function evaluateVariant(request: Request, flag: string) {

--- a/app/routes/account.test.tsx
+++ b/app/routes/account.test.tsx
@@ -1,56 +1,54 @@
 import * as React from "react";
-import { useActionData, useSearchParams } from "react-router";
+import { useActionData, useLoaderData, useSearchParams } from "react-router";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-
-import { useLoaderData } from "react-router";
 
 import { evaluateBoolean } from "../flags.server";
 import { changePassword, verifyLogin } from "../models/user.server";
 import { requireUser } from "../session.server";
 import Account, { action, loader } from "./account";
 
-vi.mock("react-router", async (importOriginal) => {
-  const actual = await importOriginal();
-
-  return {
-    ...(actual as object),
-    useNavigation: vi.fn().mockReturnValue({}),
-    useActionData: vi.fn(),
-    useLoaderData: vi.fn(),
-    useSearchParams: vi.fn(),
-    Form: ({ children }: { children: React.ReactNode }) => (
-      <form>{children}</form>
-    ),
-    Link: ({ children }: { children: React.ReactNode }) => (
-      <span>{children}</span>
-    ),
-  };
-});
-vi.mock("../session.server", async () => {
-  return {
-    requireUser: vi.fn(),
-  };
-});
-vi.mock("../models/user.server", () => {
-  return {
-    changePassword: vi.fn(),
-    verifyLogin: vi.fn(),
-  };
-});
-vi.mock("../flags.server", () => {
-  return {
-    evaluateBoolean: vi.fn(),
-    FLAGS: {
-      PASSWORD_CHANGE: "password-change",
-      DELETE_ACCOUNT: "delete-account",
-      PLEX: "plex",
-    },
-  };
-});
-
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return {
+      ...(actual as object),
+      useNavigation: vi.fn().mockReturnValue({}),
+      useActionData: vi.fn(),
+      useLoaderData: vi
+        .fn()
+        .mockReturnValue({ webhookUrl: "http://webhook.example" }),
+      useSearchParams: vi.fn(),
+      Form: ({ children }: { children: React.ReactNode }) => (
+        <form>{children}</form>
+      ),
+      Link: ({ children }: { children: React.ReactNode }) => (
+        <span>{children}</span>
+      ),
+    };
+  });
+  vi.mock("../session.server", async () => {
+    return {
+      requireUser: vi.fn(),
+    };
+  });
+  vi.mock("../models/user.server", () => {
+    return {
+      changePassword: vi.fn(),
+      verifyLogin: vi.fn(),
+    };
+  });
+  vi.mock("../flags.server", () => {
+    return {
+      evaluateBoolean: vi.fn(),
+      FLAGS: {
+        PASSWORD_CHANGE: "password-change",
+        DELETE_ACCOUNT: "delete-account",
+        PLEX: "plex",
+      },
+    };
+  });
 
   vi.mocked(useLoaderData).mockReturnValue({
     webhookUrl: "http://webhook.example",
@@ -103,7 +101,7 @@ test("renders page with password change form if feature is enabled", () => {
 test("renders page without password change form if feature is disabled", () => {
   vi.mocked(useLoaderData).mockReturnValue({
     webhookUrl: "http://webhook.example",
-    features: { passwordChange: false, deleteAccount: true },
+    features: { passwordChange: false, deleteAccount: true, plex: true },
   });
 
   render(<Account />);

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -9,6 +9,7 @@ import {
   useSearchParams,
 } from "react-router";
 
+import { evaluateBoolean, FLAGS } from "../flags.server";
 import { changePassword, verifyLogin } from "../models/user.server";
 import { requireUser } from "../session.server";
 import { getPasswordValidationError } from "../utils";
@@ -18,8 +19,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const webhookUrl = url.origin + "/plex/" + plexToken;
 
+  const features = {
+    passwordChange: await evaluateBoolean(request, FLAGS.PASSWORD_CHANGE),
+    deleteAccount: await evaluateBoolean(request, FLAGS.DELETE_ACCOUNT),
+    plex: await evaluateBoolean(request, FLAGS.PLEX),
+  };
+
   return {
     webhookUrl,
+    features,
   };
 }
 
@@ -146,7 +154,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function AccountPage() {
-  const { webhookUrl } = useLoaderData<typeof loader>();
+  const { webhookUrl, features } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const currentPasswordRef = React.useRef<HTMLInputElement>(null);
   const newPasswordRef = React.useRef<HTMLInputElement>(null);
@@ -178,114 +186,123 @@ export default function AccountPage() {
   return (
     <main className="my-8 mx-auto flex min-h-full w-full max-w-md flex-col px-8">
       <h2 className="text-xl font-bold">Change password</h2>
-      <Form method="post" className="my-4">
-        <input type="hidden" name="token" value={resetToken} />
-        {actionData?.errors.token && (
-          <p className="text-mkerror" id="password-token-error">
-            {actionData.errors.token}
-          </p>
-        )}
-        {actionData?.errors.generic && (
-          <p className="text-mkerror" id="password-generic-error">
-            {actionData.errors.generic}
-          </p>
-        )}
+      {features.passwordChange ? (
+        <Form method="post" className="my-4">
+          <input type="hidden" name="token" value={resetToken} />
+          {actionData?.errors.token && (
+            <p className="text-mkerror" id="password-token-error">
+              {actionData.errors.token}
+            </p>
+          )}
+          {actionData?.errors.generic && (
+            <p className="text-mkerror" id="password-generic-error">
+              {actionData.errors.generic}
+            </p>
+          )}
 
-        {!resetToken && (
-          <div>
+          {!resetToken && (
+            <div>
+              <label
+                htmlFor="currentPassword"
+                className="block text-sm font-medium text-mk-text"
+              >
+                Current Password
+              </label>
+              <div className="mt-1">
+                <input
+                  id="currentPassword"
+                  ref={currentPasswordRef}
+                  required
+                  name="password"
+                  type="password"
+                  aria-invalid={actionData?.errors.password ? true : undefined}
+                  aria-describedby="password-error"
+                  className="w-full rounded border border-mk-text px-2 py-1 text-lg"
+                />
+                {actionData?.errors.password && (
+                  <p className="pt-1 text-mkerror" id="password-error">
+                    {actionData.errors.password}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-4">
             <label
-              htmlFor="currentPassword"
+              htmlFor="newPassword"
               className="block text-sm font-medium text-mk-text"
             >
-              Current Password
+              New Password
             </label>
             <div className="mt-1">
               <input
-                id="currentPassword"
-                ref={currentPasswordRef}
+                id="newPassword"
+                ref={newPasswordRef}
                 required
-                name="password"
+                name="newPassword"
                 type="password"
-                aria-invalid={actionData?.errors.password ? true : undefined}
-                aria-describedby="password-error"
+                autoComplete="new-password"
+                aria-invalid={
+                  actionData?.errors.newPassword ? true : undefined
+                }
+                aria-describedby="new-password-error"
                 className="w-full rounded border border-mk-text px-2 py-1 text-lg"
               />
-              {actionData?.errors.password && (
-                <p className="pt-1 text-mkerror" id="password-error">
-                  {actionData.errors.password}
+              {actionData?.errors.newPassword && (
+                <p className="pt-1 text-mkerror" id="new-password-error">
+                  {actionData.errors.newPassword}
                 </p>
               )}
             </div>
           </div>
-        )}
 
-        <div className="mt-4">
-          <label
-            htmlFor="newPassword"
-            className="block text-sm font-medium text-mk-text"
-          >
-            New Password
-          </label>
-          <div className="mt-1">
-            <input
-              id="newPassword"
-              ref={newPasswordRef}
-              required
-              name="newPassword"
-              type="password"
-              autoComplete="new-password"
-              aria-invalid={actionData?.errors.newPassword ? true : undefined}
-              aria-describedby="new-password-error"
-              className="w-full rounded border border-mk-text px-2 py-1 text-lg"
-            />
-            {actionData?.errors.newPassword && (
-              <p className="pt-1 text-mkerror" id="new-password-error">
-                {actionData.errors.newPassword}
-              </p>
-            )}
+          <div className="my-4">
+            <label
+              htmlFor="confirmPassword"
+              className="block text-sm font-medium text-mk-text"
+            >
+              Confirm Password
+            </label>
+            <div className="mt-1">
+              <input
+                id="confirmPassword"
+                ref={passwordConfirmRef}
+                required
+                name="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                aria-invalid={
+                  actionData?.errors.confirmPassword ? true : undefined
+                }
+                aria-describedby="password-confirm-error"
+                className="w-full rounded border border-mk-text px-2 py-1 text-lg"
+              />
+              {actionData?.errors.confirmPassword && (
+                <p className="pt-1 text-mkerror" id="password-confirm-error">
+                  {actionData.errors.confirmPassword}
+                </p>
+              )}
+            </div>
           </div>
-        </div>
 
-        <div className="my-4">
-          <label
-            htmlFor="confirmPassword"
-            className="block text-sm font-medium text-mk-text"
+          <button
+            type="submit"
+            className="w-full rounded bg-mk px-4 py-2 text-white hover:bg-mk-tertiary focus:bg-mk-tertiary"
           >
-            Confirm Password
-          </label>
-          <div className="mt-1">
-            <input
-              id="confirmPassword"
-              ref={passwordConfirmRef}
-              required
-              name="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              aria-invalid={
-                actionData?.errors.confirmPassword ? true : undefined
-              }
-              aria-describedby="password-confirm-error"
-              className="w-full rounded border border-mk-text px-2 py-1 text-lg"
-            />
-            {actionData?.errors.confirmPassword && (
-              <p className="pt-1 text-mkerror" id="password-confirm-error">
-                {actionData.errors.confirmPassword}
-              </p>
-            )}
-          </div>
-        </div>
+            Change password
+          </button>
 
-        <button
-          type="submit"
-          className="w-full rounded bg-mk px-4 py-2 text-white hover:bg-mk-tertiary focus:bg-mk-tertiary"
-        >
-          Change password
-        </button>
+          {actionData?.done && <p>Your password has been changed.</p>}
+        </Form>
+      ) : (
+        <p className="my-4">
+          The password change functionality is currently disabled. Please try
+          again later.
+        </p>
+      )}
 
-        {actionData?.done && <p>Your password has been changed.</p>}
-      </Form>
-
-      {webhookUrl ? (
+      {features.plex && webhookUrl ? (
         <>
           <hr className="my-8" />
 
@@ -307,16 +324,25 @@ export default function AccountPage() {
       <hr className="my-8" />
 
       <h2 className="text-xl font-bold">Delete account</h2>
-      <p className="my-4">
-        Deleting your account will also delete all your saved data. Once
-        deleted, this data can&apos;t be restored.
-      </p>
-      <Link
-        to="/deletion"
-        className="rounded bg-mkerror py-2 px-4 text-center text-white hover:bg-mkerror-muted active:bg-mkerror-muted"
-      >
-        Delete my account and all data
-      </Link>
+      {features.deleteAccount ? (
+        <>
+          <p className="my-4">
+            Deleting your account will also delete all your saved data. Once
+            deleted, this data can&apos;t be restored.
+          </p>
+          <Link
+            to="/deletion"
+            className="rounded bg-mkerror py-2 px-4 text-center text-white hover:bg-mkerror-muted active:bg-mkerror-muted"
+          >
+            Delete my account and all data
+          </Link>
+        </>
+      ) : (
+        <p className="my-4">
+          The account deletion functionality is currently disabled. Please try
+          again later.
+        </p>
+      )}
     </main>
   );
 }

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -243,9 +243,7 @@ export default function AccountPage() {
                 name="newPassword"
                 type="password"
                 autoComplete="new-password"
-                aria-invalid={
-                  actionData?.errors.newPassword ? true : undefined
-                }
+                aria-invalid={actionData?.errors.newPassword ? true : undefined}
                 aria-describedby="new-password-error"
                 className="w-full rounded border border-mk-text px-2 py-1 text-lg"
               />

--- a/app/routes/deletion.test.tsx
+++ b/app/routes/deletion.test.tsx
@@ -109,18 +109,6 @@ test("loader should call evaluateBoolean", async () => {
   );
 });
 
-test("loader should not require user if feature is disabled", async () => {
-  vi.mocked(evaluateBoolean).mockResolvedValue(false);
-
-  await loader({
-    request: new Request("http://localhost:8080/deletion"),
-    context: {},
-    params: {},
-  });
-
-  expect(requireUserId).not.toHaveBeenCalled();
-});
-
 test("action should delete user and logout if everything ok", async () => {
   vi.mocked(requireUserId).mockResolvedValue("123");
 

--- a/app/routes/deletion.test.tsx
+++ b/app/routes/deletion.test.tsx
@@ -16,21 +16,25 @@ vi.mock("../flags.server", () => {
     },
   };
 });
-vi.mock("react-router", async (importOriginal) => {
-  const actual = await importOriginal();
-
-  return {
-    ...(actual as object),
-    useNavigation: vi.fn().mockReturnValue({}),
-    useActionData: vi.fn(),
-    useLoaderData: vi.fn(),
-    Form: ({ children }: { children: React.ReactNode }) => (
-      <form>{children}</form>
-    ),
-  };
-});
 
 beforeEach(() => {
+  vi.mock("react-router", async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return {
+      ...(actual as object),
+      useNavigation: vi.fn().mockReturnValue({}),
+      useActionData: vi.fn(),
+      useLoaderData: vi.fn(),
+      Form: ({ children }: { children: React.ReactNode }) => (
+        <form>{children}</form>
+      ),
+    };
+  });
+
+  vi.mocked(useLoaderData).mockReturnValue({
+    deleteAccountEnabled: true,
+  });
 
   vi.mock("../db.server");
 
@@ -47,10 +51,6 @@ beforeEach(() => {
     plexToken: "e4fe1d61-ab49-4e08-ace4-bc070821e9b1",
     createdAt: new Date(),
     updatedAt: new Date(),
-  });
-
-  vi.mocked(useLoaderData).mockReturnValue({
-    deleteAccountEnabled: true,
   });
 });
 

--- a/app/routes/plex.$token.test.tsx
+++ b/app/routes/plex.$token.test.tsx
@@ -1,4 +1,5 @@
 import type { ActionFunctionArgs } from "react-router";
+import { evaluateBoolean, FLAGS } from "../flags.server";
 import {
   getEpisodeByShowIdAndNumbers,
   markEpisodeAsWatched,
@@ -8,6 +9,14 @@ import { getUserByPlexToken } from "../models/user.server";
 import { action } from "./plex.$token";
 
 vi.mock("../db.server");
+vi.mock("../flags.server", () => {
+  return {
+    evaluateBoolean: vi.fn(),
+    FLAGS: {
+      PLEX: "plex",
+    },
+  };
+});
 vi.mock("../models/episode.server");
 vi.mock("../models/show.server");
 vi.mock("../models/user.server");
@@ -77,6 +86,7 @@ const createPlexPayload = (
 describe("Plex token route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(evaluateBoolean).mockResolvedValue(true);
     vi.mocked(getUserByPlexToken).mockResolvedValue(mockUser);
     vi.mocked(getShowByUserIdAndName).mockResolvedValue(mockShow);
     vi.mocked(getEpisodeByShowIdAndNumbers).mockResolvedValue(mockEpisode);
@@ -112,6 +122,26 @@ describe("Plex token route", () => {
       showId: mockShow.id,
     });
     expect(response).toEqual({});
+    expect(evaluateBoolean).toHaveBeenCalledWith(expect.any(Request), FLAGS.PLEX);
+  });
+
+  test("returns empty object if feature is disabled", async () => {
+    vi.mocked(evaluateBoolean).mockResolvedValue(false);
+
+    const formData = new FormData();
+    formData.append("payload", JSON.stringify(createPlexPayload()));
+
+    const response = await action({
+      request: new Request("http://localhost:8080/plex/token123", {
+        method: "POST",
+        body: formData,
+      }),
+      params: { token: "token123" },
+      context: {},
+    } as ActionFunctionArgs);
+
+    expect(response).toEqual({});
+    expect(getUserByPlexToken).not.toHaveBeenCalled();
   });
 
   test("returns null for non-scrobble event", async () => {

--- a/app/routes/plex.$token.test.tsx
+++ b/app/routes/plex.$token.test.tsx
@@ -122,7 +122,10 @@ describe("Plex token route", () => {
       showId: mockShow.id,
     });
     expect(response).toEqual({});
-    expect(evaluateBoolean).toHaveBeenCalledWith(expect.any(Request), FLAGS.PLEX);
+    expect(evaluateBoolean).toHaveBeenCalledWith(
+      expect.any(Request),
+      FLAGS.PLEX
+    );
   });
 
   test("returns empty object if feature is disabled", async () => {

--- a/app/routes/plex.$token.tsx
+++ b/app/routes/plex.$token.tsx
@@ -1,5 +1,6 @@
 import type { ActionFunctionArgs } from "react-router";
 
+import { evaluateBoolean, FLAGS } from "../flags.server";
 import {
   getEpisodeByShowIdAndNumbers,
   markEpisodeAsWatched,
@@ -8,6 +9,10 @@ import { getShowByUserIdAndName } from "../models/show.server";
 import { getUserByPlexToken } from "../models/user.server";
 
 export async function action({ request, params }: ActionFunctionArgs) {
+  const plexEnabled = await evaluateBoolean(request, FLAGS.PLEX);
+  if (!plexEnabled) {
+    return {};
+  }
   const body = await request.formData();
   const payload = body.get("payload");
   const parsedPayload = JSON.parse(payload as string);


### PR DESCRIPTION
This commit introduces feature flags for three key features:
- Password change (`password-change`)
- Account deletion (`delete-account`)
- Plex integration (`plex`)

The implementation uses Flipt for feature flag evaluation.

Fixes #209 