### PR TITLE
Improve scripts error handling and rename function

### DIFF
--- a/scripts/delete-episode-by-id.ts
+++ b/scripts/delete-episode-by-id.ts
@@ -27,6 +27,6 @@ if (!EPISODE_ID) {
 }
 
 deleteEpisode(EPISODE_ID).catch((e) => {
-  console.error(e);
+  console.error(e.message);
   process.exit(1);
 });

--- a/scripts/delete-episode.ts
+++ b/scripts/delete-episode.ts
@@ -68,6 +68,6 @@ const season = parseInt(TV_EPISODE_SEASON, 10);
 const number = parseInt(TV_EPISODE_NUMBER, 10);
 
 deleteEpisode(TV_SHOW_NAME, season, number).catch((e) => {
-  console.error(e);
+  console.error(e.message);
   process.exit(1);
 });

--- a/scripts/force-episode-update.ts
+++ b/scripts/force-episode-update.ts
@@ -127,6 +127,6 @@ const season = parseInt(TV_EPISODE_SEASON, 10);
 const number = parseInt(TV_EPISODE_NUMBER, 10);
 
 updateEpisode(TV_SHOW_NAME, season, number).catch((e) => {
-  console.error(e);
+  console.error(e.message);
   process.exit(1);
 });

--- a/scripts/get-new-episodes.ts
+++ b/scripts/get-new-episodes.ts
@@ -104,7 +104,6 @@ async function fetch(showId: string) {
       return await fetch(showId);
     }
 
-    console.error(error);
     process.exit(1);
   }
 }

--- a/scripts/remove-inexistent-episode-links.ts
+++ b/scripts/remove-inexistent-episode-links.ts
@@ -41,6 +41,6 @@ if (!DATABASE_URL) {
 }
 
 check().catch((e) => {
-  console.error(e);
+  console.error(e.message);
   process.exit(1);
 });

--- a/scripts/update-episodes.ts
+++ b/scripts/update-episodes.ts
@@ -72,7 +72,6 @@ async function fetch(mazeId: string) {
       return await fetch(mazeId);
     }
 
-    console.error(error);
     process.exit(1);
   }
 }
@@ -85,6 +84,6 @@ if (!DATABASE_URL) {
 }
 
 update().catch((e) => {
-  console.error(e);
+  console.error(e.message);
   process.exit(1);
 });


### PR DESCRIPTION
- The scripts in the scripts folder should not rethrow errors. Currently some do a console.error and then throw the error again. They instead should keep the log, but then instead of throwing they should just exit the process with exit code 1.
- Additionally the function name in delete-episode.ts should be updated to reflect deletion, it's not an update.