### PR TITLE
Stricter optimize queries

### DIFF
--- a/app/components/episode-card.test.tsx
+++ b/app/components/episode-card.test.tsx
@@ -14,14 +14,24 @@ beforeEach(() => {
   });
 });
 
-test("renders episode card and does not decode summary", () => {
+test("renders episode card", () => {
   const episode = {
-    ...testEpisode,
-    summary: "a &lt; b",
-    show: testShow,
+    id: testEpisode.id,
+    name: testEpisode.name,
+    season: testEpisode.season,
+    number: testEpisode.number,
+    airDate: testEpisode.airDate,
+    runtime: testEpisode.runtime,
+    imageUrl: testEpisode.imageUrl,
+    show: {
+      id: testShow.id,
+      name: testShow.name,
+      imageUrl: testShow.imageUrl,
+    },
   };
 
   render(<EpisodeCard episode={episode} />);
 
-  expect(screen.getByText("a &lt; b")).toBeInTheDocument();
+  expect(screen.getByText(testShow.name, { exact: false })).toBeInTheDocument();
+  expect(screen.getByText("S01E01", { exact: false })).toBeInTheDocument();
 });

--- a/app/components/episode-card.tsx
+++ b/app/components/episode-card.tsx
@@ -3,8 +3,11 @@ import { Link } from "react-router";
 import { padNumber } from "../utils";
 
 interface Props {
-  episode: Episode & {
-    show: Show;
+  episode: Pick<
+    Episode,
+    "id" | "name" | "season" | "number" | "airDate" | "runtime" | "imageUrl"
+  > & {
+    show: Pick<Show, "id" | "name" | "imageUrl">;
   };
 }
 
@@ -31,7 +34,6 @@ export default function EpisodeCard({ episode }: Props) {
           <p className="mt-2 text-sm text-gray-500">
             {new Date(episode.airDate).toLocaleDateString()}
           </p>
-          {episode.summary && <p className="mt-4 text-sm">{episode.summary}</p>}
         </div>
       </Link>
     </li>

--- a/app/components/episode-list.test.tsx
+++ b/app/components/episode-list.test.tsx
@@ -26,25 +26,11 @@ test("renders episodes", async () => {
 
   expect(screen.getByText(DEFAULT_EPISODES[0].name)).toBeInTheDocument();
   expect(screen.getByText(/S01E01/)).toBeInTheDocument();
-  expect(screen.getByText(DEFAULT_EPISODES[0].summary)).toBeInTheDocument();
 
   expect(screen.getByText(DEFAULT_EPISODES[1].name)).toBeInTheDocument();
   expect(screen.getByText(/S01E02/)).toBeInTheDocument();
-  expect(screen.getByText(DEFAULT_EPISODES[1].summary)).toBeInTheDocument();
 
   expect(screen.queryAllByText("Mark as watched").length).toBe(2);
-});
-
-test("does not decode summary", async () => {
-  const episodes = [
-    {
-      ...DEFAULT_EPISODES[0],
-      summary: "a &lt; b",
-    },
-  ];
-  render(<EpisodeList episodes={episodes} watchedEpisodes={[]} showId="1" />);
-
-  expect(screen.getByText("a &lt; b")).toBeInTheDocument();
 });
 
 test("renders unwatched button if watched", async () => {

--- a/app/components/episode-list.tsx
+++ b/app/components/episode-list.tsx
@@ -7,7 +7,10 @@ import { padNumber } from "../utils";
 import Spinner from "./spinner";
 
 interface Props {
-  episodes: Episode[];
+  episodes: Pick<
+    Episode,
+    "id" | "name" | "season" | "number" | "airDate" | "runtime" | "imageUrl"
+  >[];
   watchedEpisodes: Episode["id"][];
   showId: Show["id"];
 }
@@ -44,7 +47,6 @@ export default function EpisodeList({
                 {padNumber(episode.number)}) -{" "}
                 {new Date(episode.airDate).toLocaleDateString()}
               </p>
-              <p>{episode.summary}</p>
 
               {submissionEpisodeId && submissionEpisodeId === episode.id && (
                 <div className="mt-4">

--- a/app/components/show-header.tsx
+++ b/app/components/show-header.tsx
@@ -5,7 +5,23 @@ import type { Episode, Show } from "@prisma/client";
 import Spinner from "./spinner";
 
 interface Props {
-  show: Show & { archived: boolean; episodes: Episode[] };
+  show: Pick<
+    Show,
+    | "id"
+    | "name"
+    | "mazeId"
+    | "premiered"
+    | "ended"
+    | "rating"
+    | "imageUrl"
+    | "summary"
+  > & {
+    archived: boolean;
+    episodes: Pick<
+      Episode,
+      "id" | "name" | "season" | "number" | "airDate" | "runtime" | "imageUrl"
+    >[];
+  };
   watchedEpisodes: Episode["id"][];
   features: {
     markAllAsWatched: boolean;

--- a/app/components/show-tile.tsx
+++ b/app/components/show-tile.tsx
@@ -3,7 +3,10 @@ import { Link } from "react-router";
 import type { Show } from "@prisma/client";
 
 export interface Props {
-  show: Show & { archived: boolean; unwatchedEpisodesCount?: number };
+  show: Pick<Show, "id" | "name" | "imageUrl"> & {
+    archived: boolean;
+    unwatchedEpisodesCount?: number;
+  };
 }
 
 export default function ShowTile({ show }: Props) {

--- a/app/components/show-tiles.test.tsx
+++ b/app/components/show-tiles.test.tsx
@@ -6,9 +6,24 @@ import type { Show } from "@prisma/client";
 import { testShow } from "../test-utils";
 import ShowTiles from "./show-tiles";
 
-const shows: (Show & { archived: boolean })[] = [
-  { ...testShow, archived: false },
-  { ...testShow, id: "2", mazeId: "2", name: "Test Show 2", archived: false },
+const shows: (Pick<Show, "id" | "name" | "imageUrl"> & {
+  archived: boolean;
+  unwatchedEpisodesCount: number;
+})[] = [
+  {
+    id: testShow.id,
+    name: testShow.name,
+    imageUrl: testShow.imageUrl,
+    archived: false,
+    unwatchedEpisodesCount: 5,
+  },
+  {
+    id: "2",
+    name: "Test Show 2",
+    imageUrl: testShow.imageUrl,
+    archived: false,
+    unwatchedEpisodesCount: 3,
+  },
 ];
 
 beforeEach(() => {

--- a/app/components/show-tiles.tsx
+++ b/app/components/show-tiles.tsx
@@ -3,7 +3,10 @@ import type { Show } from "@prisma/client";
 import ShowTile from "./show-tile";
 
 interface Props {
-  shows: (Show & { archived: boolean })[];
+  shows: (Pick<Show, "id" | "name" | "imageUrl"> & {
+    archived: boolean;
+    unwatchedEpisodesCount: number;
+  })[];
 }
 
 export default function ShowTiles({ shows }: Props) {

--- a/app/components/upcoming-episodes-list.tsx
+++ b/app/components/upcoming-episodes-list.tsx
@@ -1,8 +1,12 @@
 import type { Episode, Show } from "@prisma/client";
 import EpisodeCard from "./episode-card";
 
-type EpisodeWithShow = Episode & {
-  show: Show;
+type EpisodeWithShow = Pick<
+  Episode,
+  "id" | "name" | "season" | "number" | "airDate" | "runtime" | "imageUrl"
+> & {
+  show: Pick<Show, "id" | "name" | "imageUrl">;
+  date?: Date;
 };
 
 interface WatchedEpisodes {

--- a/app/models/episode.server.test.ts
+++ b/app/models/episode.server.test.ts
@@ -76,13 +76,6 @@ test("getEpisodeByShowIdAndNumbers should return episode", async () => {
     },
     select: {
       id: true,
-      name: true,
-      season: true,
-      number: true,
-      airDate: true,
-      runtime: true,
-      imageUrl: true,
-      summary: true,
     },
   });
 });
@@ -164,13 +157,6 @@ test("getRecentlyWatchedEpisodes should be called with correct params", async ()
           id: true,
           name: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
-          mazeId: true,
-          premiered: true,
-          ended: true,
-          rating: true,
         },
       },
       episode: {
@@ -182,18 +168,14 @@ test("getRecentlyWatchedEpisodes should be called with correct params", async ()
           airDate: true,
           runtime: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
-          showId: true,
-          mazeId: true,
         },
       },
     },
     orderBy: {
       createdAt: "desc",
     },
-    take: 1000,
+    take: 50,
+    skip: 0,
   });
 });
 

--- a/app/models/episode.server.ts
+++ b/app/models/episode.server.ts
@@ -46,13 +46,6 @@ export async function getEpisodeByShowIdAndNumbers({
     },
     select: {
       id: true,
-      name: true,
-      season: true,
-      number: true,
-      airDate: true,
-      runtime: true,
-      imageUrl: true,
-      summary: true,
     },
   });
 
@@ -81,36 +74,28 @@ export async function getUpcomingEpisodes(userId: User["id"]) {
       airDate: true,
       runtime: true,
       imageUrl: true,
-      summary: true,
-      createdAt: true,
-      updatedAt: true,
-      showId: true,
-      mazeId: true,
       show: {
         select: {
           id: true,
           name: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
-          mazeId: true,
-          premiered: true,
-          ended: true,
-          rating: true,
         },
       },
     },
     orderBy: {
       airDate: "asc",
     },
-    take: 50,
+    take: 30,
   });
 
   return upcomingEpisodes;
 }
 
-export async function getRecentlyWatchedEpisodes(userId: User["id"]) {
+export async function getRecentlyWatchedEpisodes(
+  userId: User["id"],
+  limit = 50,
+  offset = 0
+) {
   const fromDate = new Date();
   fromDate.setMonth(fromDate.getMonth() - 11);
   fromDate.setDate(1);
@@ -131,13 +116,6 @@ export async function getRecentlyWatchedEpisodes(userId: User["id"]) {
           id: true,
           name: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
-          mazeId: true,
-          premiered: true,
-          ended: true,
-          rating: true,
         },
       },
       episode: {
@@ -149,18 +127,14 @@ export async function getRecentlyWatchedEpisodes(userId: User["id"]) {
           airDate: true,
           runtime: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
-          showId: true,
-          mazeId: true,
         },
       },
     },
     orderBy: {
       createdAt: "desc",
     },
-    take: 1000,
+    take: limit,
+    skip: offset,
   });
 
   const recentlyWatchedEpisodeList = recentlyWatchedEpisodes.map(
@@ -420,16 +394,12 @@ export async function getLast12MonthsStats(userId: User["id"]) {
           showId: true,
         },
       },
-      show: {
-        select: {
-          id: true,
-          name: true,
-        },
-      },
+      showId: true,
     },
     orderBy: {
       createdAt: "asc",
     },
+    take: 1000,
   });
 
   // Group by month

--- a/app/models/show.server.test.ts
+++ b/app/models/show.server.test.ts
@@ -650,14 +650,6 @@ test("getShowByUserIdAndName should return show by name for user", async () => {
     select: {
       id: true,
       name: true,
-      mazeId: true,
-      premiered: true,
-      ended: true,
-      rating: true,
-      imageUrl: true,
-      summary: true,
-      createdAt: true,
-      updatedAt: true,
     },
   });
   expect(result).toStrictEqual(SHOW);

--- a/app/models/show.server.ts
+++ b/app/models/show.server.ts
@@ -47,14 +47,6 @@ export async function getShowByUserIdAndName({
     select: {
       id: true,
       name: true,
-      mazeId: true,
-      premiered: true,
-      ended: true,
-      rating: true,
-      imageUrl: true,
-      summary: true,
-      createdAt: true,
-      updatedAt: true,
     },
   });
 
@@ -72,15 +64,8 @@ export async function getShowsByUserId(userId: User["id"]) {
       show: {
         select: {
           id: true,
-          mazeId: true,
           name: true,
-          premiered: true,
-          ended: true,
-          rating: true,
           imageUrl: true,
-          summary: true,
-          createdAt: true,
-          updatedAt: true,
           _count: {
             select: {
               episodes: {
@@ -197,8 +182,6 @@ export async function getShowById(showId: Show["id"], userId: User["id"]) {
             rating: true,
             imageUrl: true,
             summary: true,
-            createdAt: true,
-            updatedAt: true,
             episodes: {
               select: {
                 id: true,
@@ -208,11 +191,6 @@ export async function getShowById(showId: Show["id"], userId: User["id"]) {
                 airDate: true,
                 runtime: true,
                 imageUrl: true,
-                summary: true,
-                createdAt: true,
-                updatedAt: true,
-                showId: true,
-                mazeId: true,
               },
               orderBy: [
                 {

--- a/app/routes/plex.$token.test.tsx
+++ b/app/routes/plex.$token.test.tsx
@@ -43,22 +43,7 @@ const mockShow = {
   rating: 8.5,
 };
 
-const mockEpisode = {
-  id: "episode789",
-  createdAt: new Date(),
-  updatedAt: new Date(),
-  airDate: new Date(),
-  date: new Date(),
-  imageUrl: "https://example.com/image.png",
-  mazeId: "maze789",
-  name: "Declaration of Love",
-  number: 7,
-  season: 3,
-  runtime: 44,
-  showId: "show456",
-  summary: "Test Summary",
-  show: mockShow,
-};
+const mockEpisodeId = "episode789";
 
 interface PlexMetadata {
   grandparentTitle: string;
@@ -89,7 +74,9 @@ describe("Plex token route", () => {
     vi.mocked(evaluateBoolean).mockResolvedValue(true);
     vi.mocked(getUserByPlexToken).mockResolvedValue(mockUser);
     vi.mocked(getShowByUserIdAndName).mockResolvedValue(mockShow);
-    vi.mocked(getEpisodeByShowIdAndNumbers).mockResolvedValue(mockEpisode);
+    vi.mocked(getEpisodeByShowIdAndNumbers).mockResolvedValue({
+      id: mockEpisodeId,
+    });
     vi.mocked(markEpisodeAsWatched).mockResolvedValue(undefined);
   });
 
@@ -118,7 +105,7 @@ describe("Plex token route", () => {
     });
     expect(markEpisodeAsWatched).toHaveBeenCalledWith({
       userId: mockUser.id,
-      episodeId: mockEpisode.id,
+      episodeId: mockEpisodeId,
       showId: mockShow.id,
     });
     expect(response).toEqual({});

--- a/app/routes/tv._index.tsx
+++ b/app/routes/tv._index.tsx
@@ -32,7 +32,10 @@ function Content({
   shows,
   features,
 }: {
-  shows: (Show & { archived: boolean; unwatchedEpisodesCount: number })[];
+  shows: (Pick<Show, "id" | "name" | "imageUrl"> & {
+    archived: boolean;
+    unwatchedEpisodesCount: number;
+  })[];
   features: { search: boolean };
 }) {
   const navigation = useNavigation();

--- a/app/routes/tv.stats.tsx
+++ b/app/routes/tv.stats.tsx
@@ -156,7 +156,9 @@ export default function TVStats() {
 
       {/* Last 12 Months */}
       <div className="mt-12">
-        <h2 className="mb-4 font-title text-3xl">Last 12 Months</h2>
+        <h2 className="mb-4 font-title text-3xl">
+          Last 12 Months (or last 1000 episodes)
+        </h2>
 
         {/* Chart */}
         {last12MonthsStats.length > 0 && (


### PR DESCRIPTION
This optimizes data flow by removing more data, especially the `summary` for episodes. Additionally it limits the number of episodes to be fetched, as well as the stats. 